### PR TITLE
Added package version info

### DIFF
--- a/org2blog-pkg.el
+++ b/org2blog-pkg.el
@@ -1,0 +1,4 @@
+(define-package "org2blog" "0.4"
+  "Blog from Org mode to wordpress"
+  '((org "7.7")
+    (xml-rpc "1.6.8")))


### PR DESCRIPTION
to get the multi-elisp file package into marmalade, I needed to add a new file org2blog-pkg.el.  Adding the version info to the org2blog.el file only works when it is the only file in the package.  With this I was able to get it uploaded and tested in my emacs setup.  The uploaded package can be found here: http://marmalade-repo.org/packages/org2blog/0.4
