### PR TITLE
fix #93 : wp-upload-files-replace-urls will eat up every occurrences.

### DIFF
--- a/org2blog.el
+++ b/org2blog.el
@@ -466,8 +466,8 @@ from currently logged in."
                                                  file-name file-web-url)))))))
       (dolist (file file-all-urls)
         (setq text (replace-regexp-in-string
-                    (concat "\\(file://\\)*" (regexp-quote (car file)))
-                    (cdr file) text))))
+                    (concat "\\(<a href=\"\\|<img src=\"\\)\\(file://\\)*" (regexp-quote (car file)))
+                    (concat "\\1" (cdr file)) text))))
     text))
 
 (defun org2blog/wp-get-option (opt)


### PR DESCRIPTION
When replace a text link like [[file:boat.jpg]] with its url, search for html tags for link first such as &lt;a&gt; &lt;img&gt;. This will prevent the function from replacing some plain text.
