### PR TITLE
fix minor mode keymap prefix and allow customization (fixes #137)

### DIFF
--- a/org2blog.el
+++ b/org2blog.el
@@ -302,7 +302,7 @@ key sequence defined by `org2blog/wp-keymap-prefix' and update
     (setcdr keymap org2blog/wp-entry-mode-map)))
 
 ;; Set the mode map for org2blog.
-(unless org2blog/wp-entry-mode-map org2blog/wp-init-entry-mode-map)
+(unless org2blog/wp-entry-mode-map (org2blog/wp-init-entry-mode-map))
 
 ;;;###autoload
 (define-minor-mode org2blog/wp-mode


### PR DESCRIPTION
The official emacs key binding conventions state:

```
Don't define C-c letter as a key in Lisp programs. Sequences
consisting of C-c and a letter (either upper or lower case) are
reserved for users; they are the only sequences reserved for users,
so do not block them.

Changing all the Emacs major modes to respect this convention was a
lot of work; abandoning this convention would make that work go to
waste, and inconvenience users. Please comply with it.
```

but org2blog defines the following keys:

  (define-key org2blog/wp-map (kbd "C-c p") 'org2blog/wp-post-buffer-and-publish)
  (define-key org2blog/wp-map (kbd "C-c P") 'org2blog/wp-post-buffer-as-page-and-publish)
  (define-key org2blog/wp-map (kbd "C-c d") 'org2blog/wp-post-buffer)
  (define-key org2blog/wp-map (kbd "C-c D") 'org2blog/wp-post-buffer-as-page)
  (define-key org2blog/wp-map (kbd "C-c t") 'org2blog/wp-complete-category)

This commit makes the prefix customizable via a new
`org2blog/wp-keymap-prefix' variable, whose default is "C-c M-p".  After
changing it,`org2blog/wp-reload-entry-mode-map' must be called before
it takes effect.
