### PR TITLE
Fix access to org2blog/wp-shortcode-langs-map.

### DIFF
--- a/ox-wp.el
+++ b/ox-wp.el
@@ -59,7 +59,7 @@ contextual information."
     (if (not sc)
         (org-html-src-block src-block contents info)
       (format "[sourcecode language=\"%s\" title=\"%s\" %s]\n%s[/sourcecode]"
-              (or (plist-get lang-map lang) (car (member lang langs)) "text")
+              (or (cdr (assoc lang lang-map)) (car (member lang langs)) "text")
               (or caption "")
               (or syntaxhl "")
               (org-export-format-code-default src-block info)))))


### PR DESCRIPTION
- org2blog/wp-shortcode-langs-map is defined as an alist not a plist.
