### PR TITLE
fix defcustom for org2blog/wp-track-posts

### DIFF
--- a/org2blog.el
+++ b/org2blog.el
@@ -188,10 +188,10 @@ need NOT be present in 'org2blog/wp-sourcecode-langs."
 
 (defcustom org2blog/wp-track-posts
   (list ".org2blog.org" "Posts")
-  "File where to save logs about posts.
-Set to nil if you don't wish to track posts."
+  ".org file in which to save logs about posts, and corresponding headline
+in file under which the logs should be added."
   :group 'org2blog/wp
-  :type 'list)
+  :type '(list string string))
 
 (defcustom org2blog/wp-keymap-prefix
   "C-c M-p"


### PR DESCRIPTION
be3c8f9b changed this variable from a single string to a list of two strings, where the second value is the headline to store log entries under.

Also it appears that the code no longer works if the first value is `nil`.
