### PR TITLE
fix defcustom type for org2blog/wp-sourcecode-langs

### DIFF
--- a/org2blog.el
+++ b/org2blog.el
@@ -173,7 +173,7 @@ browser."
         "vb" "xml")
   "List of languages supported by sourcecode shortcode of WP."
   :group 'org2blog/wp
-  :type 'list)
+  :type '(repeat string))
 
 (defcustom org2blog/wp-shortcode-langs-map nil
   "Association list for source code languages supported by Org


### PR DESCRIPTION
Previously it was showing as a type mismatch.
