### PR TITLE
remove org2blog/wp-sourcecode-langs

### DIFF
--- a/org2blog.el
+++ b/org2blog.el
@@ -166,23 +166,11 @@ browser."
   :group 'org2blog/wp
   :type 'string)
 
-(defcustom org2blog/wp-sourcecode-langs
-  (list "actionscript3" "bash" "coldfusion" "cpp" "csharp" "css" "delphi"
-        "erlang" "fsharp" "diff" "groovy" "javascript" "java" "javafx" "matlab"
-        "objc" "perl" "php" "text" "powershell" "python" "ruby" "scala" "sql"
-        "vb" "xml")
-  "List of languages supported by sourcecode shortcode of WP."
-  :group 'org2blog/wp
-  :type 'list)
-
 (defcustom org2blog/wp-shortcode-langs-map nil
   "Association list for source code languages supported by Org
 and by SyntaxHighlighter.  Each element of the list maps the
 orgmode source code language (key) to the language spec that
-should be used for syntax highlighting in shortcode blocks. The
-list of target languages complements the list of languages in
-ineed not be in 'org2blog/wp-sourcecode-langs and they already
-need NOT be present in 'org2blog/wp-sourcecode-langs."
+should be used for syntax highlighting in shortcode blocks."
   :group 'org2blog/wp
   :type '(alist :key-type string :value-type string))
 
@@ -904,8 +892,6 @@ various export options."
                (if (plist-member (cdr org2blog/wp-blog) :tags-as-categories)
                    (plist-get (cdr org2blog/wp-blog) :tags-as-categories)
                  org2blog/wp-use-tags-as-categories))
-    (plist-put export-options :wp-shortcode-langs
-               org2blog/wp-sourcecode-langs)
     (plist-put export-options :wp-shortcode-lang-map
                org2blog/wp-shortcode-langs-map)
 

--- a/ox-wp.el
+++ b/ox-wp.el
@@ -49,7 +49,6 @@ contextual information."
                    (format " id=\"%s\""
                            (org-export-solidify-link-text lbl)))))
         (sc (plist-get info :wp-shortcode))
-        (langs (plist-get info :wp-shortcode-langs))
         (lang-map (plist-get info :wp-shortcode-lang-map))
         (syntaxhl (org-element-property :syntaxhl src-block)))
 
@@ -59,7 +58,7 @@ contextual information."
     (if (not sc)
         (org-html-src-block src-block contents info)
       (format "[sourcecode language=\"%s\" title=\"%s\" %s]\n%s[/sourcecode]"
-              (or (plist-get lang-map lang) (car (member lang langs)) "text")
+              (or (plist-get lang-map lang) lang "text")
               (or caption "")
               (or syntaxhl "")
               (org-export-format-code-default src-block info)))))


### PR DESCRIPTION
`org2blog/wp-sourcecode-langs` duplicates a list of supported languages which depends entirely on the version of the WordPress SyntaxHighlighter being used, so it is impossible to maintain this list to be correct for all users, and it is unrealistic to expect users to maintain it to be accurate.

Additionally, the only effect the variable has is to force the shortcode to be `text` in case an language is chosen which is not in this list. In that case, forcing it to text is almost certainly not what the user would want or expect.

Therefore it is better to adhere to the DRY rule and just eliminate this duplication.
