### PR TITLE
fix :syntaxhl by supporting #+ATTR_WP: :syntaxhl (#169)

### DIFF
--- a/README.org
+++ b/README.org
@@ -173,10 +173,14 @@
     =htmlize.el= (available in org-mode's =contrib/lisp=) to your
     =load-path=.  Wordpress's sourcecode shortcode blocks can be given
     various [[http://en.support.wordpress.com/code/posting-source-code/#configuration-parameters][configuration parameters]].  These can be passed to the
-    exported sourcecode shortcode blocks, by passing them to the babel
-    blocks using =:syntaxhl= parameter.  You could also modify the
-    default arguments passed to sourcecode shortcode blocks by
-    customizing the =org2blog/wp-sourcecode-default-params= variable.
+    exported sourcecode shortcode blocks via an =#+ATTR_WP= line
+    immediately preceding the =#+BEGIN_SRC= line, e.g.
+
+    : #+ATTR_WP: :syntaxhl light=true
+
+    You could also modify the default arguments passed to sourcecode
+    shortcode blocks by customizing the
+    =org2blog/wp-sourcecode-default-params= variable.
 *** Delete an entry or a page
     - If you are in the buffer of the entry/page, with =#+POSTID=
       present on the page, use:

--- a/ox-wp.el
+++ b/ox-wp.el
@@ -51,7 +51,7 @@ contextual information."
         (sc (plist-get info :wp-shortcode))
         (langs (plist-get info :wp-shortcode-langs))
         (lang-map (plist-get info :wp-shortcode-lang-map))
-        (syntaxhl (org-element-property :syntaxhl src-block)))
+        (syntaxhl (org-export-read-attribute :attr_wp src-block :syntaxhl)))
 
     ;; Set back the language that we reset
     (org-element-put-property src-block :language lang)


### PR DESCRIPTION
Based on a conversation on `#emacs` with `ngz` and @punchagan, it became clear that the previous code didn't work.  Thanks to `ngz` for the suggestion on a way forward.

Fixes #169.
