### PR TITLE
Remove kill-ring addition on startup function

### DIFF
--- a/org2blog.el
+++ b/org2blog.el
@@ -1245,7 +1245,6 @@ When displaying: store the information in the `kill-ring'."
               metaweblog-version
               xml-rpc-version)))
     (if value msg
-      (kill-new msg)
       (message msg))))
 
 ;;;###autoload

--- a/org2blog.el
+++ b/org2blog.el
@@ -1233,9 +1233,7 @@ closer to doing more blogging!"
 
 ;;;###autoload
 (defun org2blog-version-info (&optional value)
-  "Display critical library information or return as a VALUE if non-nil.
-
-When displaying: store the information in the `kill-ring'."
+  "Display critical library information or return as a VALUE if non-nil."
   (interactive)
   (let ((msg (format
               "Org2Blog Runtime: Org2Blog %s, Emacs %s, Org Mode %s, MetaWeblog %s, XML-RPC %s"


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following [Contribution Expectations](https://github.com/org2blog/org2blog/blob/master/docs/CONTRIBUTING.org#contribution-expectations)

Does this PR fulfill them?
- [ ] No
- [X] Yes

## Pull request type

Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

On start the runtime info is printed to msg and added to killring

Issue Number: [Replace this in with the issue number]

## What is the new behavior?

No longer added to kill-ring

## Have you updated the project documentation with the new behavior?

- [X] Yes
- [ ] No

Updated comments on function

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

It's just annoying that if i restart emacs my clipboard is corrupted, and with mobil sync it also drags my phone down with it
